### PR TITLE
6/8

### DIFF
--- a/src/ball_detection/src/dbscan.cpp
+++ b/src/ball_detection/src/dbscan.cpp
@@ -188,7 +188,7 @@ std::optional<geometry_msgs::msg::Pose> koma::BallDetect::findClosestBall(
     RCLCPP_WARN(
       this->get_logger(), "Could not transform ball position from %s to %s: %s",
       lidar_frame_id_.c_str(), odom_frame_id_.c_str(), ex.what());
-    ball_z = pose_->position.z;
+    ball_z = pose_ ? pose_->position.z : 0.0;;
   }
 
   closest_ball.position.x = ball[closest_index].getX();
@@ -620,7 +620,7 @@ sensor_msgs::msg::PointCloud2 koma::BallDetect::circle2PointCloud2(
       float angle = 2.0 * M_PI * i / NUM_POINTS;
       *iter_x = _b.getX() + _b.getR() * std::cos(angle);
       *iter_y = _b.getY() + _b.getR() * std::sin(angle);
-      *iter_z = pose_->position.z;
+      *iter_z = pose_ ? pose_->position.z : 0.0;;
 
       *iter_r = red;
       *iter_g = green;
@@ -630,7 +630,7 @@ sensor_msgs::msg::PointCloud2 koma::BallDetect::circle2PointCloud2(
     // 中心点
     *iter_x = _b.getX();
     *iter_y = _b.getY();
-    *iter_z = pose_->position.z;
+    *iter_z = pose_ ? pose_->position.z : 0.0;;
     *iter_r = red;
     *iter_g = green;
     *iter_b = blue;

--- a/src/ball_detection/src/dbscan.cpp
+++ b/src/ball_detection/src/dbscan.cpp
@@ -188,7 +188,8 @@ std::optional<geometry_msgs::msg::Pose> koma::BallDetect::findClosestBall(
     RCLCPP_WARN(
       this->get_logger(), "Could not transform ball position from %s to %s: %s",
       lidar_frame_id_.c_str(), odom_frame_id_.c_str(), ex.what());
-    ball_z = pose_ ? pose_->position.z : 0.0;;
+    ball_z = pose_ ? pose_->position.z : 0.0;
+    ;
   }
 
   closest_ball.position.x = ball[closest_index].getX();
@@ -620,7 +621,8 @@ sensor_msgs::msg::PointCloud2 koma::BallDetect::circle2PointCloud2(
       float angle = 2.0 * M_PI * i / NUM_POINTS;
       *iter_x = _b.getX() + _b.getR() * std::cos(angle);
       *iter_y = _b.getY() + _b.getR() * std::sin(angle);
-      *iter_z = pose_ ? pose_->position.z : 0.0;;
+      *iter_z = pose_ ? pose_->position.z : 0.0;
+      ;
 
       *iter_r = red;
       *iter_g = green;
@@ -630,7 +632,8 @@ sensor_msgs::msg::PointCloud2 koma::BallDetect::circle2PointCloud2(
     // 中心点
     *iter_x = _b.getX();
     *iter_y = _b.getY();
-    *iter_z = pose_ ? pose_->position.z : 0.0;;
+    *iter_z = pose_ ? pose_->position.z : 0.0;
+    ;
     *iter_r = red;
     *iter_g = green;
     *iter_b = blue;

--- a/src/behavior/include/behavior/bt.hpp
+++ b/src/behavior/include/behavior/bt.hpp
@@ -14,7 +14,7 @@ class BTNode : public rclcpp::Node
 public:
   BTNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
-  bool is_pursuit_runing() const;
+  bool is_pursuit_running() const;
   bool is_arm_control_running() const;
 
   // service setter
@@ -56,7 +56,7 @@ public:
       result);
 
 private:
-  std::atomic_bool is_pursuit_running_{false};
+  std::atomic_bool is_pursuit_goal_pending_{false};
   std::atomic_bool is_arm_control_runing_{false};
 
   // service
@@ -70,6 +70,7 @@ private:
 
   // action
   rclcpp_action::Client<inrof2026_koma_type::action::Pursuit>::SharedPtr pursuit_act_;
+  rclcpp_action::ClientGoalHandle<inrof2026_koma_type::action::Pursuit>::SharedPtr pursuit_goal_handle_;
   rclcpp_action::Client<inrof2026_koma_type::action::ArmControl>::SharedPtr arm_control_act_;
 };
 }  // namespace koma

--- a/src/behavior/include/behavior/bt.hpp
+++ b/src/behavior/include/behavior/bt.hpp
@@ -70,7 +70,8 @@ private:
 
   // action
   rclcpp_action::Client<inrof2026_koma_type::action::Pursuit>::SharedPtr pursuit_act_;
-  rclcpp_action::ClientGoalHandle<inrof2026_koma_type::action::Pursuit>::SharedPtr pursuit_goal_handle_;
+  rclcpp_action::ClientGoalHandle<inrof2026_koma_type::action::Pursuit>::SharedPtr
+    pursuit_goal_handle_;
   rclcpp_action::Client<inrof2026_koma_type::action::ArmControl>::SharedPtr arm_control_act_;
 };
 }  // namespace koma

--- a/src/behavior/src/bt.cpp
+++ b/src/behavior/src/bt.cpp
@@ -167,6 +167,14 @@ void koma::BTNode::start_path_pursuit()
     RCLCPP_WARN(this->get_logger(), "pursuit not available");
   }
 
+  // when is_pursuit_running_ is true, cancel the current pursuit goal
+  if (pursuit_goal_handle_) {
+    RCLCPP_INFO(this->get_logger(), "Canceling current pursuit goal");
+    pursuit_act_->async_cancel_goal(pursuit_goal_handle_);
+  }
+
+  is_pursuit_goal_pending_.store(true);
+
   auto goal_msg = inrof2026_koma_type::action::Pursuit::Goal();
   auto send_goal_options =
     rclcpp_action::Client<inrof2026_koma_type::action::Pursuit>::SendGoalOptions();
@@ -176,22 +184,20 @@ void koma::BTNode::start_path_pursuit()
     &BTNode::pursuit_feedback_callback, this, std::placeholders::_1, std::placeholders::_2);
   send_goal_options.result_callback =
     std::bind(&BTNode::result_callback, this, std::placeholders::_1);
-
+  
   pursuit_act_->async_send_goal(goal_msg, send_goal_options);
-  is_pursuit_running_.store(true);
 }
 
 void koma::BTNode::pursuit_goal_response_callback(
   rclcpp_action::ClientGoalHandle<inrof2026_koma_type::action::Pursuit>::SharedPtr goal_handle)
 {
   if (!goal_handle) {
-    is_pursuit_running_.store(false);
     RCLCPP_ERROR(this->get_logger(), "Pursuit goal was rejected by action server.");
     return;
   }
-
-  is_pursuit_running_.store(true);
-  RCLCPP_INFO(this->get_logger(), "Start pursuit.");
+  pursuit_goal_handle_ = goal_handle;
+  is_pursuit_goal_pending_.store(false);
+  RCLCPP_INFO(this->get_logger(), "Received pursuit goal response. Goal accepted.");
 }
 
 void koma::BTNode::pursuit_feedback_callback(
@@ -205,15 +211,31 @@ void koma::BTNode::pursuit_feedback_callback(
 void koma::BTNode::result_callback(
   const rclcpp_action::ClientGoalHandle<inrof2026_koma_type::action::Pursuit>::WrappedResult result)
 {
-  is_pursuit_running_.store(false);
+  if (
+    pursuit_goal_handle_ &&
+    pursuit_goal_handle_->get_goal_id() == result.goal_id)
+  {
+    pursuit_goal_handle_.reset();
+  } else {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "Received result for an old pursuit goal. Ignoring handle reset.");
+  }
+
+  if (result.code == rclcpp_action::ResultCode::SUCCEEDED) {
+    RCLCPP_INFO(this->get_logger(), "Pursuit succeeded.");
+  } else if (result.code == rclcpp_action::ResultCode::CANCELED) {
+    RCLCPP_INFO(this->get_logger(), "Pursuit canceled.");
+  } else if (result.code == rclcpp_action::ResultCode::ABORTED) {
+    RCLCPP_WARN(this->get_logger(), "Pursuit aborted.");
+  }
 
   if (!result.result) {
     RCLCPP_WARN(this->get_logger(), "Pursuit action returned null result.");
-  };
-  RCLCPP_INFO(this->get_logger(), "Pursuit complete.");
+  }
 }
 
-bool koma::BTNode::is_pursuit_runing() const { return is_pursuit_running_.load(); }
+bool koma::BTNode::is_pursuit_running() const { return pursuit_goal_handle_ != nullptr || is_pursuit_goal_pending_.load(); }
 
 std::optional<inrof2026_koma_type::srv::BallPosition::Response> koma::BTNode::target_ball_position()
 {

--- a/src/behavior/src/bt.cpp
+++ b/src/behavior/src/bt.cpp
@@ -382,8 +382,27 @@ int main(int argc, char * argv[])
 
   factory.registerNodeType<koma::WhileDoElseBreakNode>("WhileDoElseBreak");
 
-  std::string package_path = ament_index_cpp::get_package_share_directory("inrof2026_koma");
-  factory.registerBehaviorTreeFromFile(package_path + "/config/koma_bt.xml");
+  ros_node->declare_parameter<std::string>("config_path", "");
+
+  std::string config_path;
+  ros_node->get_parameter("config_path", config_path);
+
+  if (config_path.empty()) {
+    RCLCPP_ERROR(
+      ros_node->get_logger(),
+      "Parameter 'config_path' is empty. Please set config_path from launch file."
+    );
+    rclcpp::shutdown();
+    return 1;
+  }
+
+  RCLCPP_INFO(
+    ros_node->get_logger(),
+    "Loading behavior tree config: %s",
+    config_path.c_str()
+  );
+  
+  factory.registerBehaviorTreeFromFile(config_path);
   BT::Tree tree = factory.createTree("main");
 
   BT::Groot2Publisher groot2_publisher(tree);

--- a/src/behavior/src/bt.cpp
+++ b/src/behavior/src/bt.cpp
@@ -184,7 +184,7 @@ void koma::BTNode::start_path_pursuit()
     &BTNode::pursuit_feedback_callback, this, std::placeholders::_1, std::placeholders::_2);
   send_goal_options.result_callback =
     std::bind(&BTNode::result_callback, this, std::placeholders::_1);
-  
+
   pursuit_act_->async_send_goal(goal_msg, send_goal_options);
 }
 
@@ -211,15 +211,11 @@ void koma::BTNode::pursuit_feedback_callback(
 void koma::BTNode::result_callback(
   const rclcpp_action::ClientGoalHandle<inrof2026_koma_type::action::Pursuit>::WrappedResult result)
 {
-  if (
-    pursuit_goal_handle_ &&
-    pursuit_goal_handle_->get_goal_id() == result.goal_id)
-  {
+  if (pursuit_goal_handle_ && pursuit_goal_handle_->get_goal_id() == result.goal_id) {
     pursuit_goal_handle_.reset();
   } else {
     RCLCPP_WARN(
-      this->get_logger(),
-      "Received result for an old pursuit goal. Ignoring handle reset.");
+      this->get_logger(), "Received result for an old pursuit goal. Ignoring handle reset.");
   }
 
   if (result.code == rclcpp_action::ResultCode::SUCCEEDED) {
@@ -235,7 +231,10 @@ void koma::BTNode::result_callback(
   }
 }
 
-bool koma::BTNode::is_pursuit_running() const { return pursuit_goal_handle_ != nullptr || is_pursuit_goal_pending_.load(); }
+bool koma::BTNode::is_pursuit_running() const
+{
+  return pursuit_goal_handle_ != nullptr || is_pursuit_goal_pending_.load();
+}
 
 std::optional<inrof2026_koma_type::srv::BallPosition::Response> koma::BTNode::target_ball_position()
 {

--- a/src/behavior/src/bt.cpp
+++ b/src/behavior/src/bt.cpp
@@ -184,7 +184,7 @@ void koma::BTNode::start_path_pursuit()
     &BTNode::pursuit_feedback_callback, this, std::placeholders::_1, std::placeholders::_2);
   send_goal_options.result_callback =
     std::bind(&BTNode::result_callback, this, std::placeholders::_1);
-  
+
   pursuit_act_->async_send_goal(goal_msg, send_goal_options);
 }
 
@@ -211,15 +211,11 @@ void koma::BTNode::pursuit_feedback_callback(
 void koma::BTNode::result_callback(
   const rclcpp_action::ClientGoalHandle<inrof2026_koma_type::action::Pursuit>::WrappedResult result)
 {
-  if (
-    pursuit_goal_handle_ &&
-    pursuit_goal_handle_->get_goal_id() == result.goal_id)
-  {
+  if (pursuit_goal_handle_ && pursuit_goal_handle_->get_goal_id() == result.goal_id) {
     pursuit_goal_handle_.reset();
   } else {
     RCLCPP_WARN(
-      this->get_logger(),
-      "Received result for an old pursuit goal. Ignoring handle reset.");
+      this->get_logger(), "Received result for an old pursuit goal. Ignoring handle reset.");
   }
 
   if (result.code == rclcpp_action::ResultCode::SUCCEEDED) {
@@ -235,7 +231,10 @@ void koma::BTNode::result_callback(
   }
 }
 
-bool koma::BTNode::is_pursuit_running() const { return pursuit_goal_handle_ != nullptr || is_pursuit_goal_pending_.load(); }
+bool koma::BTNode::is_pursuit_running() const
+{
+  return pursuit_goal_handle_ != nullptr || is_pursuit_goal_pending_.load();
+}
 
 std::optional<inrof2026_koma_type::srv::BallPosition::Response> koma::BTNode::target_ball_position()
 {
@@ -412,18 +411,13 @@ int main(int argc, char * argv[])
   if (config_path.empty()) {
     RCLCPP_ERROR(
       ros_node->get_logger(),
-      "Parameter 'config_path' is empty. Please set config_path from launch file."
-    );
+      "Parameter 'config_path' is empty. Please set config_path from launch file.");
     rclcpp::shutdown();
     return 1;
   }
 
-  RCLCPP_INFO(
-    ros_node->get_logger(),
-    "Loading behavior tree config: %s",
-    config_path.c_str()
-  );
-  
+  RCLCPP_INFO(ros_node->get_logger(), "Loading behavior tree config: %s", config_path.c_str());
+
   factory.registerBehaviorTreeFromFile(config_path);
   BT::Tree tree = factory.createTree("main");
 

--- a/src/behavior/src/pursuit.cpp
+++ b/src/behavior/src/pursuit.cpp
@@ -15,7 +15,7 @@ BT::NodeStatus koma::BTPursuit::onStart()
 
 BT::NodeStatus koma::BTPursuit::onRunning()
 {
-  if (this->ros_node_->is_pursuit_runing()) {
+  if (this->ros_node_->is_pursuit_running()) {
     RCLCPP_DEBUG(this->ros_node_->get_logger(), "Pursuit is Runing");
     return BT::NodeStatus::RUNNING;
   } else {

--- a/src/inrof2026_koma/config/koma_bt.xml
+++ b/src/inrof2026_koma/config/koma_bt.xml
@@ -37,8 +37,8 @@
               <arm_ee_close/>
               <Sleep msec="5000"/>
               <arm_default_pose/>
-              <path_ball x="1.34"
-                         y="2.00"/>
+              <waypoint x="1.34"
+                        y="2.00"/>
               <pursuit/>
               <waypoint x="0.3"
                         y="2.0"/>

--- a/src/inrof2026_koma/launch/simulation.launch.py
+++ b/src/inrof2026_koma/launch/simulation.launch.py
@@ -261,7 +261,7 @@ def generate_launch_description():
                 </scan>
                 <range>
                 <min>0.02</min>
-                <max>12.0</max>
+                <max>1.0</max>
                 <resolution>0.015</resolution>
                 </range>
             </ray>

--- a/src/inrof2026_koma/launch/simulation.launch.py
+++ b/src/inrof2026_koma/launch/simulation.launch.py
@@ -533,7 +533,7 @@ def generate_launch_description():
             "Kp_normal": 1.0,
             "Ki_normal": 0.00,
             "Kd_normal": 0.00,
-            "Kp_theta": 1.0,
+            "Kp_theta": 2.0,
             "Ki_theta": 0.00,
             "Kd_theta": 0.00,
         }],

--- a/src/komarm/CMakeLists.txt
+++ b/src/komarm/CMakeLists.txt
@@ -95,7 +95,7 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
-install(DIRECTORY launch include libtorch weight
+install(DIRECTORY config launch include libtorch weight
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/src/komarm/REDME.md
+++ b/src/komarm/REDME.md
@@ -1,0 +1,6 @@
+# komarm
+## launchファイル
+ballを認識して，そこまでアームを伸ばし，liftする
+```bash
+ros2 launch komarm komarm_lift.launch.py
+```

--- a/src/komarm/config/lift.xml
+++ b/src/komarm/config/lift.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root BTCPP_format="4">
+  <BehaviorTree ID="main">
+    <KeepRunningUntilFailure>
+      <Sequence>
+        <arm_default_pose/>
+        <Sleep msec="2000"/>
+        <arm_ee_open/>
+        <Sleep msec="2000"/>
+        <target_ball_position x="{x}"
+                              y="{y}"
+                              z="{z}"/>
+        <arm_control x="{x}"
+                     y="{y}"
+                     z="{z}"/>
+        <arm_ee_close/>
+        <Sleep msec="2000"/>
+      </Sequence>
+    </KeepRunningUntilFailure>
+  </BehaviorTree>
+
+  <!-- Description of Node Models (used by Groot) -->
+  <TreeNodesModel>
+    <Action ID="arm_control"
+            editable="true">
+      <input_port name="x"/>
+      <input_port name="y"/>
+      <input_port name="z"/>
+    </Action>
+    <Action ID="arm_default_pose"
+            editable="true"/>
+    <Action ID="arm_ee_close"
+            editable="true"/>
+    <Action ID="arm_ee_open"
+            editable="true"/>
+    <Action ID="target_ball_position"
+            editable="true">
+      <output_port name="x"/>
+      <output_port name="y"/>
+      <output_port name="z"/>
+    </Action>
+  </TreeNodesModel>
+
+</root>

--- a/src/komarm/config/lift.xml
+++ b/src/komarm/config/lift.xml
@@ -7,20 +7,27 @@
         <Sleep msec="2000"/>
         <arm_ee_open/>
         <Sleep msec="2000"/>
-        <target_ball_position x="{x}"
-                              y="{y}"
-                              z="{z}"/>
-        <arm_control x="{x}"
-                     y="{y}"
-                     z="{z}"/>
-        <arm_ee_close/>
-        <Sleep msec="2000"/>
+        <WhileDoElseBreak>
+          <target_ball_position x="{x}"
+                                y="{y}"
+                                z="{z}"/>
+          <Sequence>
+            <arm_control x="{x}"
+                         y="{y}"
+                         z="{z}"/>
+            <arm_ee_close/>
+            <Sleep msec="2000"/>
+          </Sequence>
+          <Sleep msec="100000"/>
+        </WhileDoElseBreak>
       </Sequence>
     </KeepRunningUntilFailure>
   </BehaviorTree>
 
   <!-- Description of Node Models (used by Groot) -->
   <TreeNodesModel>
+    <Control ID="WhileDoElseBreak"
+             editable="true"/>
     <Action ID="arm_control"
             editable="true">
       <input_port name="x"/>

--- a/src/komarm/include/komarm/catch_influence.hpp
+++ b/src/komarm/include/komarm/catch_influence.hpp
@@ -50,6 +50,9 @@ private:
   double x_reach_th_;
   double y_reach_th_;
   double z_reach_th_;
+  // arm thresholds timer
+  rclcpp::Time arm_goal_start_time_;
+  double arm_action_timeout_sec_;
 
   // for transform
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;

--- a/src/komarm/launch/komarm_lift.launch.py
+++ b/src/komarm/launch/komarm_lift.launch.py
@@ -1,0 +1,223 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, EnvironmentVariable, PathJoinSubstitution
+from launch_ros.actions import Node
+import launch_ros
+from pathlib import Path
+
+import math
+
+def generate_launch_description():
+    inrof2026_koma_package_dir = get_package_share_directory("inrof2026_koma")
+    simulation_package_dir = get_package_share_directory("simulation")
+    komarm_package_dir = get_package_share_directory("komarm")
+    lidar_package_dir = get_package_share_directory("ldlidar_node")
+
+    # libtorch path
+    libtorch_lib = str(Path(komarm_package_dir) / 'libtorch' / 'lib')
+    weight_path = str(Path(komarm_package_dir) / "weight" / "policy.pt")
+
+    # lidar setting
+    ldlidar_params = str(Path(inrof2026_koma_package_dir) / "config" / "ldlidar_settings.yaml")
+    ldlidar_launch = str(Path(lidar_package_dir) / "launch" / "ldlidar_with_mgr.launch.py")
+
+
+    x = 0.25
+    y = 0.25
+    z = 0.25
+    theta = math.pi/2.0
+
+    world_file_path = os.path.join(
+        simulation_package_dir,
+        "worlds", 
+        "field.world"
+    )
+    komarm_urdf_path = os.path.join(
+        inrof2026_koma_package_dir,
+        "inrof2026_koma_urdf",
+        "urdf",
+        "komarm.urdf"
+    )
+
+    with open(komarm_urdf_path, "r") as infp:
+        robot_desc = infp.read()
+    robot_desc = robot_desc.replace(
+        "../meshes/",
+        f"package://inrof2026_koma/inrof2026_koma_urdf/meshes/",
+    )
+
+
+    base_footprint_joint = """
+    <link name="base_footprint"/>
+
+    <joint name="base_footprint_joint" type="fixed">
+        <parent link="base_footprint"/>
+        <child link="base_link"/>
+        <origin xyz="0 0 0.0685" rpy="0 0 0"/>
+    </joint>
+    """
+    robot_desc = robot_desc.replace(
+        "</robot>",
+        base_footprint_joint + "\n</robot>",
+    )
+
+    laser_scan_link = """
+    <link name="ldlidar_base"/>
+    <link name="ldlidar_link"/>
+
+    <joint name="base_link_to_ldlidar_base" type="fixed">
+        <parent link="base_link"/>
+        <child link="ldlidar_base"/>
+        <origin xyz="0.0765 0 -0.030" rpy="0 0 0"/>
+    </joint>
+
+    <joint name="ldlidar_base_to_scan" type="fixed">
+        <parent link="ldlidar_base"/>
+        <child link="ldlidar_link"/>
+        <origin xyz="0 0 0" rpy="0 0 1.5708"/>
+    </joint>
+    """
+    robot_desc = robot_desc.replace(
+        "</robot>",
+        laser_scan_link + "\n</robot>",
+    )
+
+    # add end effector link
+    end_effector_link = """
+    <link name="end_effector"/>
+
+    <joint name="end_effector_link" type="fixed">
+        <parent link="hand_unit_v3_1"/>
+        <child link="end_effector"/>
+        <origin xyz="0.1 0 0.02" rpy="0 0 0"/>
+    </joint>
+    """
+    robot_desc = robot_desc.replace(
+        "</robot>",
+        end_effector_link + "\n</robot>",
+    )
+    params = {"robot_description": robot_desc}
+
+
+    robot_state_publisher_node = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[params]
+    )
+
+    map_server = Node(
+        package="field",
+        executable="map_server",
+        output="screen",
+        parameters=[
+            {
+                "mesh_resource": "package://field/models/inrof_field/meshes/InrofField.dae"
+            }
+        ]
+    )
+
+    joint_manager = Node(
+        package="komarm",
+        executable="feetech_joint",
+        output="screen",
+        parameters=[
+            {
+                "port_1_2": "/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3.1:1.0",
+                "port_3_4": "/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3.2:1.0",
+                "port_5_6": "/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3.3:1.0",
+            #     "servo_1_min": -math.pi/2,
+            #     "servo_1_max":  math.pi/2,
+
+            #     "servo_2_min": 0.0,
+            #     "servo_2_max": math.pi,
+                "is_servo_2_reverse": True,
+                "is_servo_3_reverse": True,
+                "is_servo_4_reverse": True,
+            # "is_servo_4_reverse": True,
+
+            #     "servo_3_min": 0.0,
+            #     "servo_3_max": math.pi,
+
+            #     "servo_4_min": -math.pi/4.0,
+            #     "servo_4_max": math.pi/2.0,
+
+            #     "servo_5_min": -math.pi,
+            #     "servo_5_max": math.pi,
+            }
+        ]
+    )
+
+    static_from_map_to_odom = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_transform_publisher",
+        output="screen",
+        arguments=['0', '0', '0', '0', '0', '0', 'map', 'world'],
+    )
+
+    static_from_odom_to_base_link = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_transform_publisher",
+        output="screen",
+        arguments=[str(x), str(y), str(z), str(theta), '0', '0', 'odom', 'base_footprint'],
+    )
+
+    catch_influence = Node(
+        package="komarm",
+        executable="catch_influence",
+        output="screen",
+        parameters=[
+            {
+                "model_path": weight_path
+            }
+        ]
+    )
+
+    ball_detect = Node(
+        package="ball_detection",
+        executable="dbscan",
+        output="screen",
+        parameters=[{
+            "map_path": os.path.join(inrof2026_koma_package_dir, "map/"),
+        }],
+    )
+
+    bt = Node(
+        package="behavior",
+        executable="bt",
+        output="screen",
+        parameters=[{
+            "config_path": os.path.join(komarm_package_dir, "config", "lift.xml")
+        }],
+    )
+
+    ldlidar_with_mgr = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(ldlidar_launch),
+        launch_arguments={"params_file": ldlidar_params}.items(),
+    )
+
+    return LaunchDescription([
+        SetEnvironmentVariable(
+            name='LD_LIBRARY_PATH',
+            value=[
+                libtorch_lib,
+                ':',
+                EnvironmentVariable('LD_LIBRARY_PATH', default_value=''),
+            ],
+        ),
+        robot_state_publisher_node,
+        joint_manager,
+        static_from_map_to_odom,
+        static_from_odom_to_base_link,
+        map_server,
+        catch_influence,
+        ball_detect,
+        bt,
+        ldlidar_with_mgr,
+    ]) 

--- a/src/komarm/launch/komarm_lift.launch.py
+++ b/src/komarm/launch/komarm_lift.launch.py
@@ -8,6 +8,7 @@ from launch.substitutions import LaunchConfiguration, EnvironmentVariable, PathJ
 from launch_ros.actions import Node
 import launch_ros
 from pathlib import Path
+from launch.actions import ExecuteProcess
 
 import math
 
@@ -157,7 +158,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="screen",
-        arguments=['0', '0', '0', '0', '0', '0', 'map', 'world'],
+        arguments=['0', '0', '0', '0', '0', '0', 'map', 'odom'],
     )
 
     static_from_odom_to_base_link = Node(
@@ -186,6 +187,16 @@ def generate_launch_description():
         parameters=[{
             "map_path": os.path.join(inrof2026_koma_package_dir, "map/"),
         }],
+    )
+
+    pose_pub = ExecuteProcess(
+        cmd=[
+            "ros2", "topic", "pub",
+            "-r", "30",
+            "/pose",
+            "geometry_msgs/msg/Pose",
+            "{position: {x: 0.25, y: 0.25, z: 0.30}, orientation: {x: 0.0, y: 0.0, z: 0.7071068, w: 0.7071068}}",
+        ],
     )
 
     bt = Node(
@@ -220,4 +231,5 @@ def generate_launch_description():
         ball_detect,
         bt,
         ldlidar_with_mgr,
+        pose_pub
     ]) 

--- a/src/komarm/src/catch_influence.cpp
+++ b/src/komarm/src/catch_influence.cpp
@@ -61,6 +61,8 @@ CatchInfluence::CatchInfluence(const rclcpp::NodeOptions & options)
     "arm_default_pose", std::bind(
                           &CatchInfluence::arm_default_pose_callback, this, std::placeholders::_1,
                           std::placeholders::_2));
+  
+  arm_action_timeout_sec_ = this->declare_parameter<double>("arm_action_timeout_sec", 5.0);
 
   // Initialize action server
   arm_control_act_ = rclcpp_action::create_server<inrof2026_koma_type::action::ArmControl>(
@@ -161,6 +163,7 @@ void koma::CatchInfluence::handle_accepted(
     goal_handle)
 {
   goal_handle_ = goal_handle;
+  arm_goal_start_time_ = this->get_clock()->now();
 
   // target ball position based odom frame. convert position based to base_link
   geometry_msgs::msg::PoseStamped target_ball_pose_odom_frame;
@@ -217,6 +220,18 @@ void CatchInfluence::control_loop()
   //pre action = action
 
   if (!goal_handle_) return;
+
+  rclcpp::Duration elapsed = this->get_clock()->now() - arm_goal_start_time_;
+  if (elapsed.seconds() >= arm_action_timeout_sec_) {
+    RCLCPP_WARN(this->get_logger(), "Arm action timeout. Forcing success.");
+
+    std::shared_ptr<inrof2026_koma_type::action::ArmControl::Result> result_msg = std::make_shared<inrof2026_koma_type::action::ArmControl::Result>();
+    result_msg->success = true;
+
+    goal_handle_->succeed(result_msg);
+    goal_handle_.reset();
+    return;
+  }
 
   if (!has_cur_joint_state_) {
     RCLCPP_WARN(this->get_logger(), "cur_joint_state is empty");

--- a/src/komarm/src/catch_influence.cpp
+++ b/src/komarm/src/catch_influence.cpp
@@ -61,7 +61,7 @@ CatchInfluence::CatchInfluence(const rclcpp::NodeOptions & options)
     "arm_default_pose", std::bind(
                           &CatchInfluence::arm_default_pose_callback, this, std::placeholders::_1,
                           std::placeholders::_2));
-  
+
   arm_action_timeout_sec_ = this->declare_parameter<double>("arm_action_timeout_sec", 5.0);
 
   // Initialize action server
@@ -226,7 +226,8 @@ void CatchInfluence::control_loop()
   if (elapsed.seconds() >= arm_action_timeout_sec_) {
     RCLCPP_WARN(this->get_logger(), "Arm action timeout. Forcing success.");
 
-    std::shared_ptr<inrof2026_koma_type::action::ArmControl::Result> result_msg = std::make_shared<inrof2026_koma_type::action::ArmControl::Result>();
+    std::shared_ptr<inrof2026_koma_type::action::ArmControl::Result> result_msg =
+      std::make_shared<inrof2026_koma_type::action::ArmControl::Result>();
     result_msg->success = true;
 
     goal_handle_->succeed(result_msg);

--- a/src/komarm/src/catch_influence.cpp
+++ b/src/komarm/src/catch_influence.cpp
@@ -164,6 +164,7 @@ void koma::CatchInfluence::handle_accepted(
 {
   goal_handle_ = goal_handle;
   arm_goal_start_time_ = this->get_clock()->now();
+  pre_action_.position = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
   // target ball position based odom frame. convert position based to base_link
   geometry_msgs::msg::PoseStamped target_ball_pose_odom_frame;

--- a/src/komarm/src/catch_influence.cpp
+++ b/src/komarm/src/catch_influence.cpp
@@ -61,7 +61,7 @@ CatchInfluence::CatchInfluence(const rclcpp::NodeOptions & options)
     "arm_default_pose", std::bind(
                           &CatchInfluence::arm_default_pose_callback, this, std::placeholders::_1,
                           std::placeholders::_2));
-  
+
   arm_action_timeout_sec_ = this->declare_parameter<double>("arm_action_timeout_sec", 5.0);
 
   // Initialize action server
@@ -225,7 +225,8 @@ void CatchInfluence::control_loop()
   if (elapsed.seconds() >= arm_action_timeout_sec_) {
     RCLCPP_WARN(this->get_logger(), "Arm action timeout. Forcing success.");
 
-    std::shared_ptr<inrof2026_koma_type::action::ArmControl::Result> result_msg = std::make_shared<inrof2026_koma_type::action::ArmControl::Result>();
+    std::shared_ptr<inrof2026_koma_type::action::ArmControl::Result> result_msg =
+      std::make_shared<inrof2026_koma_type::action::ArmControl::Result>();
     result_msg->success = true;
 
     goal_handle_->succeed(result_msg);

--- a/src/planning/src/pursuit.cpp
+++ b/src/planning/src/pursuit.cpp
@@ -92,6 +92,7 @@ rclcpp_action::GoalResponse koma::Pursuit::handle_goal(
   const rclcpp_action::GoalUUID & uuid,
   std::shared_ptr<const inrof2026_koma_type::action::Pursuit::Goal> goal)
 {
+  RCLCPP_INFO(this->get_logger(), "Received pursuit goal request");
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
 
@@ -99,7 +100,7 @@ rclcpp_action::CancelResponse koma::Pursuit::handle_cancel(
   const std::shared_ptr<rclcpp_action::ServerGoalHandle<inrof2026_koma_type::action::Pursuit>>
     goal_handle)
 {
-  goal_handle_.reset();
+  RCLCPP_INFO(this->get_logger(), "Received request to cancel pursuit goal");
   return rclcpp_action::CancelResponse::ACCEPT;
 }
 
@@ -108,6 +109,7 @@ void koma::Pursuit::handle_accepted(
     goal_handle)
 {
   goal_handle_ = goal_handle;
+  RCLCPP_INFO(this->get_logger(), "Pursuit goal accepted");
 }
 
 void koma::Pursuit::path_callback(const nav_msgs::msg::Path::SharedPtr msg)
@@ -123,10 +125,23 @@ void koma::Pursuit::robot_pose_callback(const geometry_msgs::msg::Pose::SharedPt
 
 void koma::Pursuit::control_loop()
 {
-  if (!goal_handle_ || goal_handle_->is_canceling()) {
+  if (!goal_handle_) {
     publish_zero_velocity();
     return;
   }
+  if (goal_handle_->is_canceling()) {
+    RCLCPP_INFO(this->get_logger(), "Goal canceled.");
+    publish_zero_velocity();
+
+    std::shared_ptr<inrof2026_koma_type::action::Pursuit::Result> result_msg =
+      std::make_shared<inrof2026_koma_type::action::Pursuit::Result>();
+    result_msg->success = false;
+
+    goal_handle_->canceled(result_msg);
+    goal_handle_.reset();
+    return;
+  }
+
   if (path_.empty()) {
     publish_zero_velocity();
     return;


### PR DESCRIPTION
- ボールを拾った後の経路追従の際にロボットが回転しないように変更
- pursuitのアクションを改良．pursuit中にpursuitが呼ばれる場合は，前回のpursuitをキャンセル．goal_handle_の参照がなくなると，自動的にabortが送られるらしい．あと，idの一致も
- liftをテストするための簡易的なlaunchファイルを作成
- 実機テスト後，マージ予定